### PR TITLE
Break: PostProcessorAbstract.OnFailure simplify

### DIFF
--- a/src/VoidCore.Domain/Events/PostProcessorAbstract.cs
+++ b/src/VoidCore.Domain/Events/PostProcessorAbstract.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace VoidCore.Domain.Events
 {
     /// <summary>
@@ -10,16 +12,10 @@ namespace VoidCore.Domain.Events
         /// <inheritdoc/>
         public void Process(TRequest request, IResult<TResponse> result)
         {
-            OnBoth(request, result);
-
-            if (result.IsSuccess)
-            {
-                OnSuccess(request, result.Value);
-            }
-            else
-            {
-                OnFailure(request, result);
-            }
+            result
+                .Tee(r => OnBoth(request, r))
+                .TeeOnSuccess(response => OnSuccess(request, response))
+                .TeeOnFailure(failures => OnFailure(request, failures));
         }
 
         /// <summary>
@@ -33,8 +29,8 @@ namespace VoidCore.Domain.Events
         /// Override this method to process after a validation or event failure.
         /// </summary>
         /// <param name="request">The domain event request</param>
-        /// <param name="result">The failed result of the event</param>
-        protected virtual void OnFailure(TRequest request, IResult result) { }
+        /// <param name="failures">The failures of the result of the event</param>
+        protected virtual void OnFailure(TRequest request, IEnumerable<IFailure> failures) { }
 
         /// <summary>
         /// Override this method to process on success of the event.

--- a/src/VoidCore.Model/Logging/FallibleEventLogger.cs
+++ b/src/VoidCore.Model/Logging/FallibleEventLogger.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using VoidCore.Domain;
 using VoidCore.Domain.Events;
@@ -30,13 +31,14 @@ namespace VoidCore.Model.Logging
         /// default behavior.
         /// </summary>
         /// <param name="request">The domain event request</param>
-        /// <param name="result">The result of the event, this contains the response if successful</param>
-        protected override void OnFailure(TRequest request, IResult result)
+        /// <param name="failures">The failures of the event</param>
+        protected override void OnFailure(TRequest request, IEnumerable<IFailure> failures)
         {
             Logger.Warn(
-                $"Count: {result.Failures.Count()}",
-                $"Failures: {string.Join(" ", result.Failures.Select(failure => failure.Message))}");
-            base.OnFailure(request, result);
+                $"Count: {failures.Count()}",
+                $"Failures: {string.Join(" ", failures.Select(failure => failure.Message))}");
+
+            base.OnFailure(request, failures);
         }
     }
 }

--- a/tests/VoidCore.Test/Domain/EventTests.cs
+++ b/tests/VoidCore.Test/Domain/EventTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using Moq.Protected;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,7 +135,7 @@ namespace VoidCore.Test.Domain
         {
             var processorMock = new Mock<PostProcessorAbstract<TestRequest, TestResponse>>();
             processorMock.Protected().Setup("OnBoth", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult<TestResponse>>());
-            processorMock.Protected().Setup("OnFailure", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult>());
+            processorMock.Protected().Setup("OnFailure", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IEnumerable<IFailure>>());
             processorMock.Protected().Setup("OnSuccess", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<TestResponse>());
 
             await new TestEventOk()
@@ -142,7 +143,7 @@ namespace VoidCore.Test.Domain
                 .Handle(new TestRequest());
 
             processorMock.Protected().Verify("OnBoth", Times.Once(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult<TestResponse>>());
-            processorMock.Protected().Verify("OnFailure", Times.Never(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult>());
+            processorMock.Protected().Verify("OnFailure", Times.Never(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IEnumerable<IFailure>>());
             processorMock.Protected().Verify("OnSuccess", Times.Once(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<TestResponse>());
         }
 
@@ -151,7 +152,7 @@ namespace VoidCore.Test.Domain
         {
             var processorMock = new Mock<PostProcessorAbstract<TestRequest, TestResponse>>();
             processorMock.Protected().Setup("OnBoth", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult<TestResponse>>());
-            processorMock.Protected().Setup("OnFailure", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult>());
+            processorMock.Protected().Setup("OnFailure", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IEnumerable<IFailure>>());
             processorMock.Protected().Setup("OnSuccess", ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<TestResponse>());
 
             await new TestEventFail()
@@ -159,7 +160,7 @@ namespace VoidCore.Test.Domain
                 .Handle(new TestRequest());
 
             processorMock.Protected().Verify("OnBoth", Times.Once(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult<TestResponse>>());
-            processorMock.Protected().Verify("OnFailure", Times.Once(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IResult>());
+            processorMock.Protected().Verify("OnFailure", Times.Once(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<IEnumerable<IFailure>>());
             processorMock.Protected().Verify("OnSuccess", Times.Never(), ItExpr.IsAny<TestRequest>(), ItExpr.IsAny<TestResponse>());
         }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5",
+  "version": "0.6",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Make the method similar to TeeOnFailure. Removes the surrounding result to reduce surface.