### PR TITLE
Dev

### DIFF
--- a/src/VoidCore.AspNet/ClientApp/GetWebApplicationInfo.cs
+++ b/src/VoidCore.AspNet/ClientApp/GetWebApplicationInfo.cs
@@ -104,7 +104,7 @@ namespace VoidCore.AspNet.ClientApp
             {
                 Logger.Info(
                     $"AppName: {response.ApplicationName}",
-                    $"UserName: {response.User.Name}",
+                    $"UserName: {response.User.Login}",
                     $"UserAuthorizedAs: {string.Join(", ", response.User.AuthorizedAs)}");
 
                 base.OnSuccess(request, response);

--- a/src/VoidCore.AspNet/Logging/HttpRequestLoggingStrategy.cs
+++ b/src/VoidCore.AspNet/Logging/HttpRequestLoggingStrategy.cs
@@ -36,7 +36,7 @@ namespace VoidCore.AspNet.Logging
         {
             var request = _httpContextAccessor.HttpContext.Request;
             var traceId = _httpContextAccessor.HttpContext.TraceIdentifier;
-            var userName = _currentUserAccessor.User.Name;
+            var userName = _currentUserAccessor.User.Login;
 
             var prefix = $"{traceId}:{userName}:{request.Method}:{request.Path.Value}".PadRight(60);
             var payload = string.Join(" ", messages.Where(message => !string.IsNullOrWhiteSpace(message)));

--- a/src/VoidCore.EntityFramework/EfRepositoryAbstract.cs
+++ b/src/VoidCore.EntityFramework/EfRepositoryAbstract.cs
@@ -38,7 +38,7 @@ namespace VoidCore.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async Task<Maybe<T>> Get(IQuerySpecification<T> spec, CancellationToken cancellationToken = default)
+        public virtual async Task<Maybe<T>> Get(IQuerySpecification<T> spec, CancellationToken cancellationToken)
         {
             return await GetBaseQuery()
 #if !NETCOREAPP2_1
@@ -49,7 +49,7 @@ namespace VoidCore.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async Task<IReadOnlyList<T>> ListAll(CancellationToken cancellationToken = default)
+        public virtual async Task<IReadOnlyList<T>> ListAll(CancellationToken cancellationToken)
         {
             return await GetBaseQuery()
 #if !NETCOREAPP2_1
@@ -59,7 +59,7 @@ namespace VoidCore.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async Task<IReadOnlyList<T>> List(IQuerySpecification<T> spec, CancellationToken cancellationToken = default)
+        public virtual async Task<IReadOnlyList<T>> List(IQuerySpecification<T> spec, CancellationToken cancellationToken)
         {
             return await GetBaseQuery()
 #if !NETCOREAPP2_1
@@ -70,7 +70,7 @@ namespace VoidCore.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async Task<int> Count(IQuerySpecification<T> spec, CancellationToken cancellationToken = default)
+        public virtual async Task<int> Count(IQuerySpecification<T> spec, CancellationToken cancellationToken)
         {
             return await GetBaseQuery()
 #if !NETCOREAPP2_1

--- a/src/VoidCore.EntityFramework/EfWritableRepository.cs
+++ b/src/VoidCore.EntityFramework/EfWritableRepository.cs
@@ -17,7 +17,7 @@ namespace VoidCore.EntityFramework
         public EfWritableRepository(DbContext context, ILoggingStrategy loggingStrategy) : base(context, loggingStrategy) { }
 
         /// <inheritdoc/>
-        public virtual async Task<T> Add(T entity, CancellationToken cancellationToken = default)
+        public virtual async Task<T> Add(T entity, CancellationToken cancellationToken)
         {
             Context.Set<T>().Add(entity);
             await Context.SaveChangesAsync(cancellationToken);
@@ -25,21 +25,21 @@ namespace VoidCore.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public virtual async Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             Context.Set<T>().AddRange(entities);
             await Context.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual async Task Update(T entity, CancellationToken cancellationToken = default)
+        public virtual async Task Update(T entity, CancellationToken cancellationToken)
         {
             Context.Entry(entity).State = EntityState.Modified;
             await Context.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual async Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public virtual async Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             foreach (var entity in entities)
             {
@@ -50,14 +50,14 @@ namespace VoidCore.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async Task Remove(T entity, CancellationToken cancellationToken = default)
+        public virtual async Task Remove(T entity, CancellationToken cancellationToken)
         {
             Context.Set<T>().Remove(entity);
             await Context.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public async Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             Context.Set<T>().RemoveRange(entities);
             await Context.SaveChangesAsync(cancellationToken);

--- a/src/VoidCore.Model/Auth/DomainUser.cs
+++ b/src/VoidCore.Model/Auth/DomainUser.cs
@@ -10,18 +10,18 @@ namespace VoidCore.Model.Auth
         /// <summary>
         /// Construct a new domain user
         /// </summary>
-        /// <param name="name">UI-Friendly name for the current user</param>
+        /// <param name="login">UI-Friendly name for the current user</param>
         /// <param name="authorizedAs">Authorization policies that the user fulfills</param>
-        public DomainUser(string name, IEnumerable<string> authorizedAs)
+        public DomainUser(string login, IEnumerable<string> authorizedAs)
         {
-            Name = name;
+            Login = login;
             AuthorizedAs = authorizedAs;
         }
 
         /// <summary>
         /// UI-friendly name for the current user
         /// </summary>
-        public string Name { get; }
+        public string Login { get; }
 
         /// <summary>
         /// Names of the authorization policies that the user fulfills.

--- a/src/VoidCore.Model/Data/AuditableRepositoryDecorator.cs
+++ b/src/VoidCore.Model/Data/AuditableRepositoryDecorator.cs
@@ -65,7 +65,7 @@ namespace VoidCore.Model.Data
         private void SetCreated(IAuditable entity)
         {
             var now = _now.Moment;
-            var userName = _currentUserAccessor.User.Name;
+            var userName = _currentUserAccessor.User.Login;
 
             entity.CreatedOn = now;
             entity.CreatedBy = userName;
@@ -76,7 +76,7 @@ namespace VoidCore.Model.Data
         private void SetModified(IAuditable entity)
         {
             entity.ModifiedOn = _now.Moment;
-            entity.ModifiedBy = _currentUserAccessor.User.Name;
+            entity.ModifiedBy = _currentUserAccessor.User.Login;
         }
     }
 }

--- a/src/VoidCore.Model/Data/AuditableRepositoryDecorator.cs
+++ b/src/VoidCore.Model/Data/AuditableRepositoryDecorator.cs
@@ -27,14 +27,14 @@ namespace VoidCore.Model.Data
         }
 
         /// <inheritdoc/>
-        public override Task<T> Add(T entity, CancellationToken cancellationToken = default)
+        public override Task<T> Add(T entity, CancellationToken cancellationToken)
         {
             SetCreated(entity);
             return InnerRepository.Add(entity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public override Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public override Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             foreach (var entity in entities)
             {
@@ -45,14 +45,14 @@ namespace VoidCore.Model.Data
         }
 
         /// <inheritdoc/>
-        public override Task Update(T entity, CancellationToken cancellationToken = default)
+        public override Task Update(T entity, CancellationToken cancellationToken)
         {
             SetModified(entity);
             return InnerRepository.Update(entity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public override Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public override Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             foreach (var entity in entities)
             {

--- a/src/VoidCore.Model/Data/IReadOnlyRepository.cs
+++ b/src/VoidCore.Model/Data/IReadOnlyRepository.cs
@@ -16,26 +16,26 @@ namespace VoidCore.Model.Data
         /// </summary>
         /// <param name="spec">The specification that describes the entity to get</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task<Maybe<T>> Get(IQuerySpecification<T> spec, CancellationToken cancellationToken = default);
+        Task<Maybe<T>> Get(IQuerySpecification<T> spec, CancellationToken cancellationToken);
 
         /// <summary>
         /// List all entities in the repository.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task<IReadOnlyList<T>> ListAll(CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<T>> ListAll(CancellationToken cancellationToken);
 
         /// <summary>
         /// List al entities that match a specification.
         /// </summary>
         /// <param name="spec">The specification that describes entities to get</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task<IReadOnlyList<T>> List(IQuerySpecification<T> spec, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<T>> List(IQuerySpecification<T> spec, CancellationToken cancellationToken);
 
         /// <summary>
         /// Count entities that match a specification.
         /// </summary>
         /// <param name="spec">The specification that describes entities to count</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task<int> Count(IQuerySpecification<T> spec, CancellationToken cancellationToken = default);
+        Task<int> Count(IQuerySpecification<T> spec, CancellationToken cancellationToken);
     }
 }

--- a/src/VoidCore.Model/Data/IWritableRepository.cs
+++ b/src/VoidCore.Model/Data/IWritableRepository.cs
@@ -15,41 +15,41 @@ namespace VoidCore.Model.Data
         /// </summary>
         /// <param name="entity">The entity to add</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task<T> Add(T entity, CancellationToken cancellationToken = default);
+        Task<T> Add(T entity, CancellationToken cancellationToken);
 
         /// <summary>
         /// Add many entities to the repository.
         /// </summary>
         /// <param name="entities">Entities to add</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken = default);
+        Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken);
 
         /// <summary>
         /// The entity to update within the repository.
         /// </summary>
         /// <param name="entity">The altered entity to update</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task Update(T entity, CancellationToken cancellationToken = default);
+        Task Update(T entity, CancellationToken cancellationToken);
 
         /// <summary>
         /// Update many entities in the repository.
         /// </summary>
         /// <param name="entities">The altered entities to update</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken = default);
+        Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove an entity from the repository.
         /// </summary>
         /// <param name="entity">The entity to remove</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task Remove(T entity, CancellationToken cancellationToken = default);
+        Task Remove(T entity, CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove many entities from the repository
         /// </summary>
         /// <param name="entities">The entities to remove</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken = default);
+        Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken);
     }
 }

--- a/src/VoidCore.Model/Data/RepositoryDecoratorAbstract.cs
+++ b/src/VoidCore.Model/Data/RepositoryDecoratorAbstract.cs
@@ -26,61 +26,61 @@ namespace VoidCore.Model.Data
         }
 
         /// <inheritdoc/>
-        public virtual Task<T> Add(T entity, CancellationToken cancellationToken = default)
+        public virtual Task<T> Add(T entity, CancellationToken cancellationToken)
         {
             return InnerRepository.Add(entity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public virtual Task AddRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             return InnerRepository.AddRange(entities, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task<int> Count(IQuerySpecification<T> spec, CancellationToken cancellationToken = default)
+        public virtual Task<int> Count(IQuerySpecification<T> spec, CancellationToken cancellationToken)
         {
             return InnerRepository.Count(spec, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task<Maybe<T>> Get(IQuerySpecification<T> spec, CancellationToken cancellationToken = default)
+        public virtual Task<Maybe<T>> Get(IQuerySpecification<T> spec, CancellationToken cancellationToken)
         {
             return InnerRepository.Get(spec, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task<IReadOnlyList<T>> List(IQuerySpecification<T> spec, CancellationToken cancellationToken = default)
+        public virtual Task<IReadOnlyList<T>> List(IQuerySpecification<T> spec, CancellationToken cancellationToken)
         {
             return InnerRepository.List(spec, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task<IReadOnlyList<T>> ListAll(CancellationToken cancellationToken = default)
+        public virtual Task<IReadOnlyList<T>> ListAll(CancellationToken cancellationToken)
         {
             return InnerRepository.ListAll(cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task Remove(T entity, CancellationToken cancellationToken = default)
+        public virtual Task Remove(T entity, CancellationToken cancellationToken)
         {
             return InnerRepository.Remove(entity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public virtual Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             return InnerRepository.RemoveRange(entities, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task Update(T entity, CancellationToken cancellationToken = default)
+        public virtual Task Update(T entity, CancellationToken cancellationToken)
         {
             return InnerRepository.Update(entity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public virtual Task UpdateRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             return InnerRepository.UpdateRange(entities, cancellationToken);
         }

--- a/src/VoidCore.Model/Data/SoftDeletableRepositoryDecorator.cs
+++ b/src/VoidCore.Model/Data/SoftDeletableRepositoryDecorator.cs
@@ -47,7 +47,7 @@ namespace VoidCore.Model.Data
         private void SetDeleted(ISoftDeletable entity)
         {
             entity.DeletedOn = _now.Moment;
-            entity.DeletedBy = _currentUserAccessor.User.Name;
+            entity.DeletedBy = _currentUserAccessor.User.Login;
             entity.IsDeleted = true;
         }
     }

--- a/src/VoidCore.Model/Data/SoftDeletableRepositoryDecorator.cs
+++ b/src/VoidCore.Model/Data/SoftDeletableRepositoryDecorator.cs
@@ -27,14 +27,14 @@ namespace VoidCore.Model.Data
         }
 
         /// <inheritdoc/>
-        public override Task Remove(T entity, CancellationToken cancellationToken = default)
+        public override Task Remove(T entity, CancellationToken cancellationToken)
         {
             SetDeleted(entity);
             return InnerRepository.Update(entity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public override Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+        public override Task RemoveRange(IEnumerable<T> entities, CancellationToken cancellationToken)
         {
             foreach (var entity in entities)
             {

--- a/src/VoidCore.Model/Emailing/IEmailSender.cs
+++ b/src/VoidCore.Model/Emailing/IEmailSender.cs
@@ -13,6 +13,6 @@ namespace VoidCore.Model.Emailing
         /// </summary>
         /// <param name="email">The email to send</param>
         /// <param name="cancellationToken">The cancellation token to cancel the task</param>
-        Task SendEmail(Email email, CancellationToken cancellationToken = default);
+        Task SendEmail(Email email, CancellationToken cancellationToken);
     }
 }

--- a/tests/VoidCore.Test/AspNet/ClientApp/GetWebApplicationInfoTests.cs
+++ b/tests/VoidCore.Test/AspNet/ClientApp/GetWebApplicationInfoTests.cs
@@ -55,7 +55,7 @@ namespace VoidCore.Test.AspNet.ClientApp
             var appInfo = result.Value;
 
             Assert.Equal("AppName", appInfo.ApplicationName);
-            Assert.Equal("UserName", appInfo.User.Name);
+            Assert.Equal("UserName", appInfo.User.Login);
             Assert.Equal(new[] { "policy1", "policy2" }, appInfo.User.AuthorizedAs);
             Assert.Equal("header-name", appInfo.AntiforgeryTokenHeaderName);
             Assert.Equal("request-token", appInfo.AntiforgeryToken);

--- a/tests/VoidCore.Test/EfIntegration/EfRepositoryTests.cs
+++ b/tests/VoidCore.Test/EfIntegration/EfRepositoryTests.cs
@@ -16,12 +16,12 @@ namespace VoidCore.Test.AspNet.Data
             using var context = Deps.FoodStuffsContext();
             var data = context.Seed().FoodStuffsData();
 
-            var recipes = await data.Recipes.ListAll();
+            var recipes = await data.Recipes.ListAll(default);
             var recipeToFind = recipes.First();
 
             var byId = new RecipesByIdWithCategoriesSpecification(recipeToFind.Id);
 
-            var recipe = await data.Recipes.Get(byId);
+            var recipe = await data.Recipes.Get(byId, default);
 
             Assert.True(recipe.HasValue);
             Assert.Equal(recipeToFind.Id, recipe.Value.Id);
@@ -35,7 +35,7 @@ namespace VoidCore.Test.AspNet.Data
 
             var byId = new RecipesByIdWithCategoriesSpecification(-22);
 
-            var recipe = await data.Recipes.Get(byId);
+            var recipe = await data.Recipes.Get(byId, default);
 
             Assert.True(recipe.HasNoValue);
         }
@@ -206,17 +206,17 @@ namespace VoidCore.Test.AspNet.Data
             using var context = Deps.FoodStuffsContext();
             var data = context.Seed().FoodStuffsData();
 
-            var recipes = await data.Recipes.ListAll();
+            var recipes = await data.Recipes.ListAll(default);
             var recipeToDelete = recipes.First();
 
             var byId = new RecipesByIdWithCategoriesSpecification(recipeToDelete.Id);
 
-            var recipe = await data.Recipes.Get(byId).UnwrapAsync();
+            var recipe = await data.Recipes.Get(byId, default).UnwrapAsync();
 
-            await data.CategoryRecipes.RemoveRange(recipe.CategoryRecipe.AsReadOnly());
-            await data.Recipes.Remove(recipe);
+            await data.CategoryRecipes.RemoveRange(recipe.CategoryRecipe.AsReadOnly(), default);
+            await data.Recipes.Remove(recipe, default);
 
-            var recipeMaybe = await data.Recipes.Get(byId);
+            var recipeMaybe = await data.Recipes.Get(byId, default);
 
             Assert.True(recipeMaybe.HasNoValue);
         }
@@ -233,7 +233,7 @@ namespace VoidCore.Test.AspNet.Data
             Assert.True(result.IsSuccess);
             Assert.True(result.Value.Id > 0);
 
-            var maybeRecipe = await data.Recipes.Get(new RecipesByIdWithCategoriesSpecification(result.Value.Id));
+            var maybeRecipe = await data.Recipes.Get(new RecipesByIdWithCategoriesSpecification(result.Value.Id), default);
 
             Assert.True(maybeRecipe.HasValue);
             Assert.Equal(Deps.DateTimeServiceLate.Moment, maybeRecipe.Value.CreatedOn);
@@ -250,7 +250,7 @@ namespace VoidCore.Test.AspNet.Data
             using var context = Deps.FoodStuffsContext();
             var data = context.Seed().FoodStuffsData();
 
-            var existingRecipeId = (await data.Recipes.ListAll()).First().Id;
+            var existingRecipeId = (await data.Recipes.ListAll(default)).First().Id;
 
             var result = await new SaveRecipe.Handler(data)
                 .Handle(new SaveRecipe.Request(existingRecipeId, "New", "New", "New", null, 20, new[] { "Category2", "Category3", "Category4" }));
@@ -258,7 +258,7 @@ namespace VoidCore.Test.AspNet.Data
             Assert.True(result.IsSuccess);
             Assert.Equal(existingRecipeId, result.Value.Id);
 
-            var updatedRecipe = await data.Recipes.Get(new RecipesByIdWithCategoriesSpecification(existingRecipeId));
+            var updatedRecipe = await data.Recipes.Get(new RecipesByIdWithCategoriesSpecification(existingRecipeId), default);
             Assert.True(updatedRecipe.HasValue);
             Assert.Equal(Deps.DateTimeServiceEarly.Moment, updatedRecipe.Value.CreatedOn);
             Assert.Equal(Deps.DateTimeServiceLate.Moment, updatedRecipe.Value.ModifiedOn);
@@ -274,16 +274,16 @@ namespace VoidCore.Test.AspNet.Data
             using var context = Deps.FoodStuffsContext();
             var data = context.Seed().FoodStuffsData();
 
-            var recipes = await data.Recipes.ListAll();
+            var recipes = await data.Recipes.ListAll(default);
 
             foreach (var recipe in recipes)
             {
                 recipe.Name = "changeMe";
             }
 
-            await data.Recipes.UpdateRange(recipes);
+            await data.Recipes.UpdateRange(recipes, default);
 
-            var updatedRecipes = await data.Recipes.ListAll()
+            var updatedRecipes = await data.Recipes.ListAll(default)
                 .MapAsync(recs => recs.Where(r => r.Name == "changeMe").ToList());
 
             Assert.Equal(3, updatedRecipes.Count);

--- a/tests/VoidCore.Test/EfIntegration/TestModels/Events/ListRecipes.cs
+++ b/tests/VoidCore.Test/EfIntegration/TestModels/Events/ListRecipes.cs
@@ -29,7 +29,7 @@ namespace VoidCore.Test.AspNet.Data.TestModels.Events
 
                 var allSearch = new RecipesSearchSpecification(searchCriteria);
 
-                var totalCount = await _data.Recipes.Count(allSearch);
+                var totalCount = await _data.Recipes.Count(allSearch, cancellationToken);
 
                 var pagedSearch = new RecipesSearchSpecification(
                     criteria: searchCriteria,
@@ -38,7 +38,7 @@ namespace VoidCore.Test.AspNet.Data.TestModels.Events
                     page: request.Page,
                     take: request.Take);
 
-                var recipes = await _data.Recipes.List(pagedSearch);
+                var recipes = await _data.Recipes.List(pagedSearch, cancellationToken);
 
                 return recipes
                     .Select(recipe => new RecipeListItemDto(

--- a/tests/VoidCore.Test/EfIntegration/TestModels/Events/SaveRecipe.cs
+++ b/tests/VoidCore.Test/EfIntegration/TestModels/Events/SaveRecipe.cs
@@ -34,14 +34,14 @@ namespace VoidCore.Test.AspNet.Data.TestModels.Events
                     return await maybeRecipe.Value
                         .Tee(r => Transfer(request, r))
                         .TeeAsync(r => _data.Recipes.Update(r, cancellationToken))
-                        .TeeAsync(r => ManageCategories(request, r))
+                        .TeeAsync(r => ManageCategories(request, r, cancellationToken))
                         .MapAsync(r => Ok(EntityMessage.Create("Recipe updated.", r.Id)));
                 }
 
                 return await new Recipe()
                     .Tee(r => Transfer(request, r))
                     .TeeAsync(r => _data.Recipes.Add(r, cancellationToken))
-                    .TeeAsync(r => ManageCategories(request, r))
+                    .TeeAsync(r => ManageCategories(request, r, cancellationToken))
                     .MapAsync(r => Ok(EntityMessage.Create("Recipe added.", r.Id)));
             }
 
@@ -54,7 +54,7 @@ namespace VoidCore.Test.AspNet.Data.TestModels.Events
                 recipe.PrepTimeMinutes = request.PrepTimeMinutes;
             }
 
-            private async Task ManageCategories(Request request, Recipe recipe)
+            private async Task ManageCategories(Request request, Recipe recipe, CancellationToken cancellationToken)
             {
                 var requested = request.Categories
                     .Where(n => !string.IsNullOrWhiteSpace(n))
@@ -64,23 +64,23 @@ namespace VoidCore.Test.AspNet.Data.TestModels.Events
                 var categoriesThatMatchRequestedSpec = new CategoriesSpecification(
                     c => requested.Contains(c.Name.ToLower().Trim()));
 
-                var categoriesExist = (await _data.Categories.List(categoriesThatMatchRequestedSpec))
+                var categoriesExist = (await _data.Categories.List(categoriesThatMatchRequestedSpec, cancellationToken))
                     .Select(c => c.Name.ToLower().Trim());
 
                 // Add categories that don't exist
                 await requested
                     .Where(n => !categoriesExist.Contains(n))
                     .Select(n => new Category { Name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(n) })
-                    .TeeAsync(r => _data.Categories.AddRange(r));
+                    .TeeAsync(r => _data.Categories.AddRange(r, cancellationToken));
 
                 // Remove relations that are no longer needed
                 await recipe.CategoryRecipe
                     .Where(r => !requested.Contains(r.Category.Name.ToLower().Trim()))
-                    .TeeAsync(r => _data.CategoryRecipes.RemoveRange(r));
+                    .TeeAsync(r => _data.CategoryRecipes.RemoveRange(r, cancellationToken));
 
                 // Add relations that don't exist
                 await _data.Categories
-                    .List(categoriesThatMatchRequestedSpec)
+                    .List(categoriesThatMatchRequestedSpec, cancellationToken)
                     .MapAsync(categories => categories
                         .Where(c => !recipe.CategoryRecipe
                             .Select(r => r.Category.Name.ToLower().Trim())
@@ -90,7 +90,7 @@ namespace VoidCore.Test.AspNet.Data.TestModels.Events
                             RecipeId = recipe.Id,
                             CategoryId = c.Id
                         }))
-                    .TeeAsync(r => _data.CategoryRecipes.AddRange(r));
+                    .TeeAsync(r => _data.CategoryRecipes.AddRange(r, cancellationToken));
             }
         }
 

--- a/tests/VoidCore.Test/Model/Data/AuditableRepositoryDecoratorTests.cs
+++ b/tests/VoidCore.Test/Model/Data/AuditableRepositoryDecoratorTests.cs
@@ -29,7 +29,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = repoMock.Object.AddAuditability(dateTimeService, currentUserAccessorMock.Object);
 
-            await decorator.Add(entity);
+            await decorator.Add(entity, default);
 
             Assert.Equal("userName", entity.CreatedBy);
             Assert.Equal(date, entity.CreatedOn);
@@ -57,7 +57,7 @@ namespace VoidCore.Test.Model.Data
 
             var decoratedRepo = repoMock.Object.AddAuditability(dateTimeService, currentUserAccessorMock.Object);
 
-            await decoratedRepo.AddRange(entities);
+            await decoratedRepo.AddRange(entities, default);
 
             Assert.Equal("userName", entities[0].CreatedBy);
             Assert.Equal(date, entities[0].CreatedOn);
@@ -85,7 +85,7 @@ namespace VoidCore.Test.Model.Data
 
             var decoratedRepo = repoMock.Object.AddAuditability(dateTimeService, currentUserAccessorMock.Object);
 
-            await decoratedRepo.Update(entity);
+            await decoratedRepo.Update(entity, default);
 
             Assert.Equal(default, entity.CreatedBy);
             Assert.Equal(default, entity.CreatedOn);
@@ -113,7 +113,7 @@ namespace VoidCore.Test.Model.Data
 
             var decoratedRepo = repoMock.Object.AddAuditability(dateTimeService, currentUserAccessorMock.Object);
 
-            await decoratedRepo.UpdateRange(entities);
+            await decoratedRepo.UpdateRange(entities, default);
 
             Assert.Equal(default, entities[0].CreatedBy);
             Assert.Equal(default, entities[0].CreatedOn);

--- a/tests/VoidCore.Test/Model/Data/RepositoryDecoratorAbstractTests.cs
+++ b/tests/VoidCore.Test/Model/Data/RepositoryDecoratorAbstractTests.cs
@@ -19,7 +19,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = new EmptyDecorator(repoMock.Object);
 
-            await decorator.Add(entity);
+            await decorator.Add(entity, default);
 
             repoMock.Verify(r => r.Add(It.IsAny<TestEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             repoMock.VerifyNoOtherCalls();
@@ -35,7 +35,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = new EmptyDecorator(repoMock.Object);
 
-            await decorator.AddRange(entities);
+            await decorator.AddRange(entities, default);
 
             repoMock.Verify(r => r.AddRange(It.IsAny<List<TestEntity>>(), It.IsAny<CancellationToken>()), Times.Once);
             repoMock.VerifyNoOtherCalls();
@@ -51,7 +51,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = new EmptyDecorator(repoMock.Object);
 
-            await decorator.Update(entity);
+            await decorator.Update(entity, default);
 
             repoMock.Verify(r => r.Update(It.IsAny<TestEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             repoMock.VerifyNoOtherCalls();
@@ -67,7 +67,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = new EmptyDecorator(repoMock.Object);
 
-            await decorator.UpdateRange(entities);
+            await decorator.UpdateRange(entities, default);
 
             repoMock.Verify(r => r.UpdateRange(It.IsAny<List<TestEntity>>(), It.IsAny<CancellationToken>()), Times.Once);
             repoMock.VerifyNoOtherCalls();
@@ -83,7 +83,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = new EmptyDecorator(repoMock.Object);
 
-            await decorator.Remove(entity);
+            await decorator.Remove(entity, default);
 
             repoMock.Verify(r => r.Remove(It.IsAny<TestEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             repoMock.VerifyNoOtherCalls();
@@ -99,7 +99,7 @@ namespace VoidCore.Test.Model.Data
 
             var decorator = new EmptyDecorator(repoMock.Object);
 
-            await decorator.RemoveRange(entities);
+            await decorator.RemoveRange(entities, default);
 
             repoMock.Verify(r => r.RemoveRange(It.IsAny<List<TestEntity>>(), It.IsAny<CancellationToken>()), Times.Once);
             repoMock.VerifyNoOtherCalls();

--- a/tests/VoidCore.Test/Model/Data/SoftDeletableRepositoryDecorator.cs
+++ b/tests/VoidCore.Test/Model/Data/SoftDeletableRepositoryDecorator.cs
@@ -32,7 +32,7 @@ namespace VoidCore.Test.Model.Data
 
             var decoratedRepo = repoMock.Object.AddSoftDeletability(dateTimeService, currentUserAccessorMock.Object);
 
-            await decoratedRepo.Remove(entity);
+            await decoratedRepo.Remove(entity, default);
 
             Assert.Equal("userName", entity.DeletedBy);
             Assert.Equal(date, entity.DeletedOn);
@@ -62,7 +62,7 @@ namespace VoidCore.Test.Model.Data
 
             var decoratedRepo = repoMock.Object.AddSoftDeletability(dateTimeService, currentUserAccessorMock.Object);
 
-            await decoratedRepo.RemoveRange(entities);
+            await decoratedRepo.RemoveRange(entities, default);
 
             Assert.Equal("userName", entities[0].DeletedBy);
             Assert.Equal(date, entities[0].DeletedOn);


### PR DESCRIPTION
Breaking API changes for CloseCall.

Remove the default cancellation tokens from services because we keep forgetting to pass them through. Make it more explicit that you want "default" or an actual token.

Rename current user Name to Login for clarity that it's not a person's name.