### PR TITLE
BREAKING: RequestValidator now returns Result<Request>.

### DIFF
--- a/src/VoidCore.Model/Events/IRequestValidator.cs
+++ b/src/VoidCore.Model/Events/IRequestValidator.cs
@@ -6,13 +6,13 @@ namespace VoidCore.Model.Events
     /// A validator to be run against a validatable entity.
     /// </summary>
     /// <typeparam name="T">The type of request to be validated</typeparam>
-    public interface IRequestValidator<in T>
+    public interface IRequestValidator<T>
     {
         /// <summary>
         /// Run the validator against the supplied entity and return validation errors if input is invalid.
         /// </summary>
         /// <param name="request">The entity to validate</param>
         /// <returns>Validation errors or an empty array if input is valid.</returns>
-        IResult Validate(T request);
+        IResult<T> Validate(T request);
     }
 }

--- a/src/VoidCore.Model/RuleValidator/RuleValidatorAbstract.cs
+++ b/src/VoidCore.Model/RuleValidator/RuleValidatorAbstract.cs
@@ -16,13 +16,14 @@ namespace VoidCore.Model.RuleValidator
         private readonly List<RuleBuilder<T>> _ruleBuilders = new();
 
         /// <inheritdoc/>
-        public IResult Validate(T request)
+        public IResult<T> Validate(T request)
         {
             request.EnsureNotNull(nameof(request));
 
             return _ruleBuilders
                 .Select(builder => builder.Build().Run(request))
-                .Combine();
+                .Combine()
+                .Select(() => request);
         }
 
         /// <summary>

--- a/tests/VoidCore.Test/Model/EventTests.cs
+++ b/tests/VoidCore.Test/Model/EventTests.cs
@@ -206,7 +206,7 @@ namespace VoidCore.Test.Model
         private static Mock<IRequestValidator<TestRequest>> MockIRequestValidatorOk()
         {
             var validatorMock = new Mock<IRequestValidator<TestRequest>>();
-            validatorMock.Setup(v => v.Validate(It.IsAny<TestRequest>())).Returns(Result.Ok());
+            validatorMock.Setup(v => v.Validate(It.IsAny<TestRequest>())).Returns<TestRequest>(request => Result.Ok(request));
             return validatorMock;
         }
 
@@ -214,7 +214,7 @@ namespace VoidCore.Test.Model
         {
             var validatorMock = new Mock<IRequestValidator<TestRequest>>();
             validatorMock.Setup(v => v.Validate(It.IsAny<TestRequest>()))
-                .Returns(Result.Fail<TestResponse>(new Failure("request invalid")));
+                .Returns(Result.Fail<TestRequest>(new Failure("request invalid")));
             return validatorMock;
         }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0",
+  "version": "9.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This only has a small possibility of breaking existing apps.
Also fixed bad test mock return.